### PR TITLE
Add drawing module

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import raffle from './modules/raffle'
 import bets from './modules/bets'
 import reddit from './modules/reddit'
 import streamtime from './modules/streamtime'
+import drawing from './modules/drawing'
 
 export default function main(confile = 'config.json') {
   const conf = JSON.parse(readFile(confile))
@@ -22,6 +23,7 @@ export default function main(confile = 'config.json') {
                                  conf.channel.slice(1)
                                : conf.channel
                     , db: db }))
+  wb.use(drawing())
 
   return wb
 }

--- a/src/modules/drawing.js
+++ b/src/modules/drawing.js
@@ -1,0 +1,123 @@
+import assign from 'object-assign'
+
+const debug = require('debug')('wololobot:drawing')
+
+const removeFromArr = (arr, el) => {
+  let i
+  while ((i = arr.indexOf(el)) !== -1) {
+    arr.splice(i, 1)
+  }
+  return arr
+}
+
+export default function(opts) {
+
+  opts = assign({
+    subChances: 2     // Number of tickets for subs
+  , normalChances: 1  // Number of tickets for non-subs
+  }, opts)
+
+  let entrants = []
+  let winners = []
+  let nEntrants = 0
+  let open = false
+
+  function pickRandom() {
+    debug(`Picking a random entrant out of ${entrants}`)
+    let rand = entrants[Math.floor(Math.random() * entrants.length)]
+    winners.push(rand)
+    entrants = removeFromArr(entrants, rand)
+  }
+
+  function winnersStr() {
+    if (winners.length === 0) {
+      return 'There are no winners!'
+    } else if (winners.length === 1) {
+      return `The winner is ${winners[0]}`
+    }
+    let out = 'The winners are: '
+    winners.forEach((winner) => {
+      out += `${winner}, `
+    })
+    return out.slice(0, -2)
+  }
+
+  return function drawing(bot) {
+    bot.command('!play', (message) => {
+      if (!open) {
+        return
+      }
+      message.user =  message.user.toLowerCase()
+      if (entrants.indexOf(message.user) !== -1) {
+        return
+      }
+      nEntrants++
+      if (message.tags.subscriber === '1') {
+        for (let i = 0; i < opts.subChances; i++) {
+          entrants.push(message.user)
+        }
+      } else {
+        for (let i = 0; i < opts.normalChances; i++) {
+          entrants.push(message.user)
+        }
+      }
+    })
+
+    bot.command('!draw open'
+                , { rank: 'mod' }
+                , (message) => {
+      entrants = []
+      open = true
+      nEntrants = 0
+      bot.send('New drawing opened! To enter, type !play. Subscribers have double the chances to' +
+               'win. Type !draw close <number of players> to end the drawing.')
+    })
+
+    bot.command('!draw close'
+                , { rank: 'mod' }
+                , (message, number) => {
+      open = false
+      number = parseInt(number)
+      if (number.isNaN) {
+        bot.send(`@${message.user} Usage: !draw close <number of players>`)
+        return
+      }
+      if (number > nEntrants) {
+        bot.send(`@${message.user} Only ${nEntrants} people entered the drawing. Do !draw close` +
+                 `again with a number up to ${nEntrants}.`)
+        return
+      }
+      winners = []
+      for (let i = number; i>0; i--) {
+        pickRandom()
+      }
+      bot.send(winnersStr())
+    })
+
+    bot.command('!draw reroll'
+                , { rank: 'mod' }
+                , (message, user) => {
+      if (user === void 0) {
+        bot.send(`@${message.user} Usage: !draw reroll <user>`)
+        return
+      }
+      user = user.toLowerCase()
+      let i = winners.indexOf(user)
+      if (i === -1) {
+        bot.send(`'${user}' didn't win the drawing!`)
+        return
+      }
+      if (entrants.length === 0) {
+        bot.send('There are no entrants remaining! Open another drawing with !draw open')
+        return
+      }
+      winners.splice(i, 1)
+      pickRandom()
+      bot.send(`${user} has been replaced with ${winners[winners.length - 1]}`)
+    })
+
+    bot.command('!winners', (message) => {
+      bot.send(winnersStr())
+    })
+  }
+}

--- a/src/modules/drawing.js
+++ b/src/modules/drawing.js
@@ -69,7 +69,8 @@ export default function(opts) {
       entrants = []
       open = true
       nEntrants = 0
-      bot.send('New drawing opened! To enter, type !play. Subscribers have double the chances to' +
+      bot.send('New drawing opened! To enter, type !play. Subscribers have ' +
+               `${opts.subChances / opts.normalChances}x higher chances to ` +
                'win. Type !draw close <number of players> to end the drawing.')
     })
 
@@ -78,7 +79,7 @@ export default function(opts) {
                 , (message, number) => {
       open = false
       number = parseInt(number)
-      if (number.isNaN) {
+      if (isNaN(number)) {
         bot.send(`@${message.user} Usage: !draw close <number of players>`)
         return
       }


### PR DESCRIPTION
Adds the option to do drawings with Wololobot without using Florins.
This adds the following commands:

                  Command | Description
--------------------------|---------------------------------------------------
             `!draw open` | Opens a drawing
 `!draw close `*`number`* | Closes the drawing and chooses *`number`* winners
`!draw reroll `*`winner`* | Chooses a different entrant instead of *`winner`*
                  `!play` | Enter the drawing
               `!winners` | Displays the winners of the drawing

The `drawing` module takes an optional argument `opts` with the attributes `subChances` and `normalChances`. Subscribers to the channel are entered `subChances` times into the drawing, non-subscribers are entered `normalChances` times.
`subChances` defaults to `2`, `normalChances` defaults to `1`.