### PR TITLE
Account for internal server errors

### DIFF
--- a/src/modules/streamtime.js
+++ b/src/modules/streamtime.js
@@ -192,16 +192,25 @@ export default function(opts) {
             reject(err)
           } else {
             streams = []
-            foundPanel = panels.some(panel => {
-              if ((panel.data.title !== void 0 &&
-                  panel.data.title.toLowerCase() === 'schedule') ||
-                  panel.data.image === opts.schedImage) {
-                streams = parseSchedule(strip(panel.html_description))
-                debug(strip(panel.html_description))
-                return true
+            try {
+              foundPanel = panels.some(panel => {
+                if ((panel.data.title !== void 0 &&
+                    panel.data.title.toLowerCase() === 'schedule') ||
+                    panel.data.image === opts.schedImage) {
+                  streams = parseSchedule(strip(panel.html_description))
+                  debug(strip(panel.html_description))
+                  return true
+                }
+              })
+              resolve()
+            } catch (e) {
+              if (!(e instanceof TypeError)) {
+                throw e
               }
-            })
-            resolve()
+              // Probably an Internal Server Error of sorts, just ignore that.
+              debug(`An error occured while trying to get the panels: ${e}`)
+              reject(e)
+            }
           }
         }
       )


### PR DESCRIPTION
If Twitch responds with an Internal Server Error of sorts, the parsing is going to fail:

```
TypeError: Object <html><body><h1>503 Service Unavailable</h1>
No server is available to handle this request.
</body></html>
 has no method 'some'
    at Request._callback (/home/jazzpi/lobbysimbot/lib/modules/streamtime.js:223:31)
    at Request.self.callback (/home/jazzpi/lobbysimbot/node_modules/request/request.js:354:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/home/jazzpi/lobbysimbot/node_modules/request/request.js:1207:14)
    at Request.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/home/jazzpi/lobbysimbot/node_modules/request/request.js:1153:12)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:929:16
    at process._tickCallback (node.js:419:13)
```